### PR TITLE
Update php-agent-compatibility-requirements.mdx

### DIFF
--- a/src/content/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements.mdx
+++ b/src/content/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements.mdx
@@ -173,7 +173,7 @@ Supported PHP frameworks include:
 
     <tr>
       <td>
-        [Drupal 6.x, 7.x, 8.x, and 9.x](/docs/agents/php-agent/frameworks-libraries/drupal-specific-functionality)
+        [Drupal 6.x, 7.x, 8.x, and 9.0/9.1/9.2/9.3](/docs/agents/php-agent/frameworks-libraries/drupal-specific-functionality)
       </td>
 
       <td>


### PR DESCRIPTION
The PHP team is changing the Drupal compatibility specification to match current agent capabilities.