### PR TITLE
chore(PHP): Relnotes for PHP agent release 11.1.0.14

### DIFF
--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-11-1-0-14.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-11-1-0-14.mdx
@@ -1,0 +1,30 @@
+---
+subject: PHP agent
+releaseDate: '2024-08-26'
+version: 11.1.0.14
+downloadLink: 'https://download.newrelic.com/php_agent/archive/11.1.0.14'
+features: []
+bugs: ['Fixes unresolved strlcpy symbol error on Linux platforms using glibc >= 2.39']
+security: []
+---
+
+## New Relic PHP agent v11.1.0.14
+
+### Bug Fixes
+
+* Fixes an issue with newrelic.so not able to resolve the strlcpy symbol on Linux using glibc version >= 2.39
+
+### Support statement
+
+* New Relic recommends that you upgrade the agent regularly and at a minimum every 3 months. For more information on supported agent versions and EOL timelines, check out our [PHP EOL policy](https://docs.newrelic.com/docs/apm/agents/php-agent/getting-started/php-agent-eol-policy/).
+* The [PHP agent compatibility and requirements](https://docs.newrelic.com/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements/) page should be consulted for the latest information on supported PHP versions and platforms.
+
+<Callout variant="important">
+  **For installations using an unsupported PHP version or platform, it's highly recommended that you disable the auto-update mechanisms for the PHP agent packages.** This can be done by adding the PHP agent packages to an exclusion list for package upgrades. Or you could version pin the PHP agent package to an agent version that supports the old, unsupported feature(s). Failure to prevent upgrades may result in a newer agent release being installed and the removal of support for the required, unsupported features. This would disrupt APM data collection.
+
+  The PHP agent packages that are affected are:
+
+  * newrelic-php5
+  * newrelic-php5-common
+  * newrelic-daemon
+</Callout>


### PR DESCRIPTION
These are release notes for an upcoming PHP agent release.

*** Please hold off merging until I let you know we've completed the release ***

Thanks!
