### PR TITLE
chore(PHP): Removes RHEL/Centos 7 from compatibility

### DIFF
--- a/src/content/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements.mdx
+++ b/src/content/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements.mdx
@@ -283,7 +283,7 @@ Based on the information above the PHP agent, can be installed on operating syst
       </td>
 
       <td>
-        7, 8, 9
+        8, 9
       </td>
 
       <td>

--- a/src/content/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements.mdx
+++ b/src/content/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements.mdx
@@ -301,7 +301,7 @@ Based on the information above the PHP agent, can be installed on operating syst
       </td>
 
       <td>
-        7, 8, 9
+        8, 9
       </td>
 
       <td>


### PR DESCRIPTION
The PHP team is updating the PHP agent compatibility page to reflect the dropping of support for RHEL 7/Centos 7.

